### PR TITLE
feat: List 컴포넌트 추가

### DIFF
--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -61,7 +61,13 @@ List.defaultProps = {
   direction: 'row',
 };
 List.propTypes = {
+  /**
+   리스트 형식
+   */
   as: PropTypes.oneOf(['ul', 'ol']),
+  /**
+   리스트 방향. 해당 값에 따라 방향키 네비게이션이 달라짐
+   */
   direction: PropTypes.oneOf(['row', 'col']),
   children: PropTypes.node,
 };
@@ -71,5 +77,4 @@ const StyledList = styled.ul`
   flex-direction: ${({ $d }) => ($d === 'row' ? 'row' : 'column')};
   justify-content: ${({ $d }) => ($d === 'row' ? 'space-between' : 'center')};
   align-items: ${({ $d }) => ($d === 'row' ? 'center' : 'space-between')};
-  list-style: none;
 `;

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { PropTypes } from 'prop-types';
+import styled from 'styled-components';
+import {
+  getFocusableChildren,
+  arrowNavigation,
+  KEYS,
+  getCompatibleKey,
+} from '../../utils';
+
+export function List({ as, direction, children, ...restProps }) {
+  const containerRef = useRef(null);
+
+  let listItems = [];
+
+  useEffect(() => {
+    const $container = containerRef.current;
+    listItems = getFocusableChildren($container);
+  }, []);
+
+  const handleKeyDown = (e) => {
+    const key = getCompatibleKey(e, direction);
+
+    switch (key) {
+      case KEYS.HOME:
+      case KEYS.END:
+        e.preventDefault();
+        if (!e.ctrlKey) {
+          key === KEYS.HOME ? listItems[0].focus() : listItems.at(-1).focus();
+          e.stopPropagation();
+        }
+        break;
+      case KEYS.ARROW_UP:
+      case KEYS.ARROW_DOWN:
+      case KEYS.ARROW_LEFT:
+      case KEYS.ARROW_RIGHT:
+        e.preventDefault();
+        arrowNavigation(direction, listItems, key);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <StyledList
+      as={as}
+      ref={containerRef}
+      aria-orientation={direction === 'row' ? 'horizontal' : 'vertical'}
+      $d={direction}
+      onKeyDown={handleKeyDown}
+      {...restProps}
+    >
+      {children}
+    </StyledList>
+  );
+}
+
+List.defaultProps = {
+  as: 'ul',
+  direction: 'row',
+};
+List.propTypes = {
+  as: PropTypes.oneOf(['ul', 'ol']),
+  direction: PropTypes.oneOf(['row', 'col']),
+  children: PropTypes.node,
+};
+
+const StyledList = styled.ul`
+  display: flex;
+  flex-direction: ${({ $d }) => ($d === 'row' ? 'row' : 'column')};
+  justify-content: ${({ $d }) => ($d === 'row' ? 'space-between' : 'center')};
+  align-items: ${({ $d }) => ($d === 'row' ? 'center' : 'space-between')};
+  list-style: none;
+`;

--- a/src/components/List/List.stories.jsx
+++ b/src/components/List/List.stories.jsx
@@ -1,0 +1,36 @@
+import { List } from './List';
+import { ListItem } from './ListItem';
+
+export default {
+  title: 'List',
+  component: List,
+  args: {
+    children: [
+      <ListItem key={1}>test1</ListItem>,
+      <ListItem key={2}>test2</ListItem>,
+      <ListItem key={3}>test3</ListItem>,
+      <ListItem key={4}>test4</ListItem>,
+      <ListItem key={5}>test5</ListItem>,
+    ],
+  },
+};
+
+const Template = (args) => <List {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  direction: 'col',
+};
+
+export const Styled = Template.bind({});
+Default.args = {
+  direction: 'col',
+  css: `
+    width: 500px;
+    height: 500px;
+    background-color: #54a1a1;
+    & li{
+      color: red;
+    }
+  `,
+};

--- a/src/components/List/List.stories.jsx
+++ b/src/components/List/List.stories.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { List } from './List';
 import { ListItem } from './ListItem';
 
@@ -5,32 +6,57 @@ export default {
   title: 'List',
   component: List,
   args: {
-    children: [
-      <ListItem key={1}>test1</ListItem>,
-      <ListItem key={2}>test2</ListItem>,
-      <ListItem key={3}>test3</ListItem>,
-      <ListItem key={4}>test4</ListItem>,
-      <ListItem key={5}>test5</ListItem>,
-    ],
+    as: 'ul',
+    direction: 'row',
+    children: [1, 2, 3, 4, 5].map((key) => (
+      <ListItem key={key}>
+        <a href="#">ListItem {key}</a>
+      </ListItem>
+    )),
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+        키보드 네비게이션을 지원하는 리스트 컴포넌트
+        - direction prop에 따라 좌우 또는 위아래 방향키로 아이템 탐색
+        - Home/End 키로 리스트의 맨 처음과 마지막 아이템으로 이동
+        `,
+      },
+    },
   },
 };
 
 const Template = (args) => <List {...args} />;
 
-export const Default = Template.bind({});
-Default.args = {
+export const RowList = Template.bind({});
+
+export const ColumnList = Template.bind({});
+ColumnList.args = {
+  as: 'ol',
   direction: 'col',
 };
+ColumnList.parameters = {
+  docs: {
+    description: {
+      story: '순서가 있는 리스트 - 세로 방향',
+    },
+  },
+};
 
-export const Styled = Template.bind({});
-Default.args = {
+export const StyledList = Template.bind({});
+StyledList.args = {
   direction: 'col',
-  css: `
-    width: 500px;
-    height: 500px;
-    background-color: #54a1a1;
-    & li{
-      color: red;
-    }
-  `,
+  children: ['red', 'yellow', 'coral', 'green', 'pink'].map((key) => (
+    <ListItem key={key} style={{ height: '100px', background: key }}>
+      <a href="#">ListItem {key}</a>
+    </ListItem>
+  )),
+};
+StyledList.parameters = {
+  docs: {
+    description: {
+      story: '스타일을 적용한 리스트 - 세로 방향',
+    },
+  },
 };

--- a/src/components/List/ListItem.jsx
+++ b/src/components/List/ListItem.jsx
@@ -1,0 +1,11 @@
+import styled, { css } from 'styled-components';
+
+export function ListItem(props) {
+  const customCss = css`
+    width: 100px;
+    color: red;
+  `;
+  return <Li css={customCss} {...props} />;
+}
+
+const Li = styled.li``;

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,0 +1,2 @@
+export * from './List';
+export * from './ListItem';

--- a/src/components/Test.jsx
+++ b/src/components/Test.jsx
@@ -1,35 +1,35 @@
-import styled from 'styled-components';
-import theme from '../utils/theme';
-import { Alert } from './Alert/index';
-import React, { children, useState } from 'react';
-// import addIcon from './../assets/icon/Icon-add.svg'
-// import {ReactComponent as CheckIcon} from './../assets/icon/Icon-check.svg'
-
-// console.log(addIcon, CheckIcon);
-
-// const Button = styled.button`
-//     color:red;
-//     border: 1px solid black;
-// `
+import { List, ListItem } from './';
 
 export function Test() {
-  const [alert, setAlert] = useState(false);
-
-  const showAlert = () => {
-    setAlert(!alert);
-  };
-
   return (
     <>
-      <button className="trigger" onClick={showAlert}>
-        example
-      </button>
-      {alert && (
-        <Alert width="300px" height="100px">
-          내용을 입력하세요😊
-        </Alert>
-      )}
-      <button>1</button>
+      <List
+        test={`
+        width: 500px;
+        height: 500px;
+        background: red;
+      `}
+      >
+        <ListItem style={{ color: 'red' }}>test1</ListItem>
+        <ListItem>test2</ListItem>
+        <ListItem>test3</ListItem>
+        <ListItem>test4</ListItem>
+        <ListItem>test5</ListItem>
+      </List>
+      <List
+        direction="col"
+        test={`
+        width: 500px;
+        height: 500px;
+        background: red;
+      `}
+      >
+        <ListItem style={{ color: 'red' }}>test1</ListItem>
+        <ListItem>test2</ListItem>
+        <ListItem>test3</ListItem>
+        <ListItem>test4</ListItem>
+        <ListItem>test5</ListItem>
+      </List>
     </>
   );
 }

--- a/src/components/Test.jsx
+++ b/src/components/Test.jsx
@@ -3,32 +3,33 @@ import { List, ListItem } from './';
 export function Test() {
   return (
     <>
-      <List
-        test={`
-        width: 500px;
-        height: 500px;
-        background: red;
-      `}
-      >
-        <ListItem style={{ color: 'red' }}>test1</ListItem>
-        <ListItem>test2</ListItem>
-        <ListItem>test3</ListItem>
-        <ListItem>test4</ListItem>
-        <ListItem>test5</ListItem>
+      <List>
+        <ListItem>
+          <a href="#">Test1</a>
+        </ListItem>
+        <ListItem>
+          <a href="#">Test2</a>
+        </ListItem>
+        <ListItem>
+          <a href="#">Test3</a>
+        </ListItem>
+        <ListItem>
+          <a href="#">Test4</a>
+        </ListItem>
       </List>
-      <List
-        direction="col"
-        test={`
-        width: 500px;
-        height: 500px;
-        background: red;
-      `}
-      >
-        <ListItem style={{ color: 'red' }}>test1</ListItem>
-        <ListItem>test2</ListItem>
-        <ListItem>test3</ListItem>
-        <ListItem>test4</ListItem>
-        <ListItem>test5</ListItem>
+      <List direction="col">
+        <ListItem>
+          <a href="#">Test5</a>
+        </ListItem>
+        <ListItem>
+          <a href="#">Test6</a>
+        </ListItem>
+        <ListItem>
+          <a href="#">Test7</a>
+        </ListItem>
+        <ListItem>
+          <a href="#">Test8</a>
+        </ListItem>
       </List>
     </>
   );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
-export { Test } from './Test';
-export * from './Alert/index';
+export * from './Test';
+export * from './Alert';
+export * from './List';

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,11 @@
-import React, { createElement as h, StrictMode } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Test } from './components/index';
+import { Test } from './components/Test';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
+
+// console.log(Test);
 
 root.render(
   <StrictMode>

--- a/src/utils/focus-tab.js
+++ b/src/utils/focus-tab.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-undef */
+const focusableSelector = `
+  a[href], 
+  area[href], 
+  button, 
+  input, 
+  select, 
+  textarea, 
+  iframe, 
+  summary, 
+  details, 
+  video[controls], 
+  audio[controls], 
+  [contenteditable=""], 
+  [contenteditable="true"], 
+  [tabindex]
+`
+  .replace(/\n\s+/g, '')
+  .trim();
+
+const tabbableSelector = focusableSelector.replace(
+  /\[tabindex\]/,
+  '[tabindex]:not([tabindex^="-"])'
+);
+
+export const isFocusableElement = (node) => {
+  const $wrapper = document.createElement('div');
+  $wrapper.append(node);
+  return Boolean($wrapper.querySelector(focusableSelector));
+};
+
+export const getFocusableChild = (node) =>
+  Array.from(node.querySelector(focusableSelector));
+
+export const getFocusableChildren = (node) =>
+  Array.from(node.querySelectorAll(focusableSelector));
+
+export const getTabbableChildren = (node) =>
+  Array.from(node.querySelectorAll(tabbableSelector));
+
+export const removeTabbable = (node) => node.setAttribute('tabindex', -1);
+export const restoreTabbable = (node) => node.setAttribute('tabindex', 0);
+export const toggleTabbable = (node, force) => {
+  if (force === undefined) {
+    node.setAttribute('tabindex', node.getAttribute('tabindex') === 0 ? -1 : 0);
+  } else {
+    force ? restoreTabbable(node) : removeTabbable(node);
+  }
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,3 @@
 export * from './theme';
 export * from './focus-tab';
 export * from './keyboardNavigation';
-export * from './validation';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,4 @@
 export * from './theme';
+export * from './focus-tab';
+export * from './keyboardNavigation';
+export * from './validation';

--- a/src/utils/keyboardNavigation.js
+++ b/src/utils/keyboardNavigation.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-undef */
+
+const DIRECTION = {
+  ROW: 'row',
+  COL: 'col',
+};
+
+export const KEYS = {
+  ARROW_UP: 'ArrowUp',
+  ARROW_DOWN: 'ArrowDown',
+  ARROW_RIGHT: 'ArrowRight',
+  ARROW_LEFT: 'ArrowLeft',
+  SHIFT: 'Shift',
+  CONTROL: 'Control',
+  ALT: 'Alt',
+  META: 'Meta',
+  ENTER: 'Enter',
+  TAB: 'Tab',
+  END: 'End',
+  HOME: 'Home',
+  PAGE_UP: 'PageUp',
+  PAGE_DOWN: 'PageDown',
+  ESCAPE: 'Escape',
+};
+
+const platform =
+  navigator?.userAgentData?.platform || navigator?.platform || 'unknown';
+const isMacOS = platform.includes('macOS');
+
+export const getCompatibleKey = (keyEvent, direction) => {
+  const { altKey, metaKey, key } = keyEvent;
+  if (!isMacOS) {
+    return key;
+  }
+  const isVertical = direction === DIRECTION.COL;
+  if (metaKey) {
+    if (isVertical && key === KEYS.ARROW_UP) return KEYS.HOME;
+    if (isVertical && key === KEYS.ARROW_DOWN) return KEYS.END;
+    if (!isVertical && key === KEYS.ARROW_LEFT) return KEYS.HOME;
+    if (!isVertical && key === KEYS.ARROW_RIGHT) return KEYS.END;
+  }
+  if (altKey) {
+    if (isVertical && key === KEYS.ARROW_UP) return KEYS.PAGE_UP;
+    if (isVertical && key === KEYS.ARROW_DOWN) return KEYS.PAGE_DOWN;
+    if (!isVertical && key === KEYS.ARROW_LEFT) return KEYS.PAGE_UP;
+    if (!isVertical && key === KEYS.ARROW_RIGHT) return KEYS.PAGE_DOWN;
+  }
+  return key;
+};
+
+export const arrowNavigation = (direction, focusableElements, key) => {
+  const activeElementIdx = focusableElements.findIndex(
+    (element) => element === document.activeElement
+  );
+  if (activeElementIdx === -1) {
+    return;
+  }
+
+  const moveForward = key.includes(
+    direction === DIRECTION.ROW ? KEYS.ARROW_RIGHT : KEYS.ARROW_DOWN
+  );
+
+  const nextActiveElementIdx = moveForward
+    ? activeElementIdx + 1
+    : activeElementIdx - 1;
+
+  focusableElements[nextActiveElementIdx]?.focus();
+};


### PR DESCRIPTION
## 개요

- 키보드 네비게이션을 제공하는 리스트 컴포넌트입니다.

## 작업사항

- direction prop으로 네비게이션 방향을 결정합니다(row/col).
  - direction에 따라 ↑↓ 또는 ←→키로 포커스를 이동합니다.
  - Tab/Shift+Tab은 모든 direction에서 동작합니다.
- 키 설명
  - ↑/←: 이전 요소로 포커스 이동. 현재 포커스된 요소가 계층 내 처음 요소일 경우 이동하지 않음.
  - ↓/→: 다음 요소로 포커스 이동. 현재 포커스된 요소가 계층 내 마지막 요소일 경우 이동하지 않음.
  - Home(macOS의 경우 ⌘+↑/←): 리스트 내 첫번째 요소로 포커스 이동
  - End(macOS의 경우 ⌘+↓/→): 리스트 내 마지막 요소로 포커스 이동


✅ close #16 
