### PR TITLE
fix: Title type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Title
 
 ## Demo
 
-Coming soon...
+[DemoPage](https://allwais.github.io/allWAIs)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-wai",
-  "version": "0.0.14",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-wai",
-      "version": "0.0.14",
+      "version": "0.0.17",
       "license": "MIT",
       "dependencies": {
         "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wai",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "index.cjs.js",
   "types": "index.d.ts",

--- a/src/Title/Title.tsx
+++ b/src/Title/Title.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import { A11yHidden } from '../A11yHidden';
 
-export interface ITitleProps {
-  lv: 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6';
+export interface ITitleProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> {
+  lv?: 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6';
   hidden?: boolean;
   focusable?: boolean;
   children?: string;
-  restProps?:unknown[];
+  restProps?: unknown[];
   forwardedAs?: string | React.ComponentType<any>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Alert } from './Alert';
 import { A11yHidden } from './A11yHidden';
 import { Title } from './Title';
-export { Alert, A11yHidden, Title };
+import { Link } from './Link';
+export { Alert, A11yHidden, Title, Link };


### PR DESCRIPTION


## 개요
Title 컴포넌트 heading에 알맞는 속성 및 lv Default props 이용을 위하여 undefined 속성 추가

## 작업사항

이전 Title type
export interface ITitleProps {
    lv: 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6';
    hidden?: boolean;
    focusable?: boolean;
    children?: string;
    restProps?: unknown[];
    forwardedAs?: string | React.ComponentType<any>;
}
제안 Title type
export interface ITitleProps extends React.DetailedHTMLProps<React.HTMLAttributes, HTMLHeadingElement>{
    lv?: 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6';
    hidden?: boolean;
    focusable?: boolean;
    children?: string;
    forwardedAs?: string | React.ComponentType<any>;
}
1. heading에 사용할 수 있는 기본 attribute를 사용하기 위하여 HTMLAttributes를 확장하였습니다.
2. lv의 default props가 존재하지만 추가로 요구하는 것을 제외하기 위해 lv에 undefined 속성을 넣기 위해 lv?:로 변경하였습니다

## 추후 개선사항

- (없으면 지우셔도 됩니다.)

✅ close #24 