### PR TITLE
feat: add Breadcrumb component

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ root.render(
 
 A11yHidden
 Alert
+Breadcrumb
+Switch
 Title
 
 ## Demo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wai",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "main": "index.cjs.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wai",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "index.cjs.js",
   "types": "index.d.ts",

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -1,4 +1,4 @@
-import React = require("react");
+import React from "react";
 import styled from "styled-components";
 /**
  * type

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,86 @@
+import React = require("react");
+import styled from "styled-components";
+/**
+ * type
+ */
+interface BreadcrumbSplitter {
+  splitter?: string;
+}
+interface PatialPath {
+  href: string;
+  map?: { [key: string]: string };
+  src: string;
+}
+interface BreadCrumb {
+  src?: string;
+  root?: string;
+  map?: { [key: string]: string };
+  width?: string;
+  splitter?: string;
+}
+/**
+ * style
+ */
+export const StyledBreadcrumb = styled.nav<BreadcrumbSplitter>`
+  padding: 0.8em 1em;
+  border: 1px solid hsl(0deg 0% 90%);
+  border-radius: 4px;
+  background: hsl(300deg 14% 97%);
+  & ol {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+  }
+  & li {
+    display: inline;
+  }
+  & li + li::before {
+    margin: 0 0.25em;
+    content: ${(props) => `'${props.splitter || '/'}'`};
+  }
+  & [aria-current='page'] {
+    color: #000;
+    font-weight: 700;
+    text-decoration: none;
+  }
+`;
+function PatialPath({ ...props }: PatialPath) {
+  if (props.map && props.map[props.src] === '') return null;
+  return (
+    <li>
+      <a href={props.href}>
+        {props.map ? props.map[props.src] ?? props.map[props.href] : props.src}
+      </a>
+    </li>
+  );
+}
+export function Breadcrumb({ ...props }: BreadCrumb) {
+  const src = props.src ? new URL(props.src) : window.location;
+  let root = props.root ?? src.origin;
+
+  return (
+    <StyledBreadcrumb
+      splitter={props.splitter}
+      aria-label="Breadcrumb"
+      style={{ width: props.width }}
+    >
+      <ol>
+        <PatialPath {...props} src={root} href={root} />
+        {src.href
+          .replace(root, '')
+          .split('/')
+          .map((path, idx) => {
+            if (path.trim() !== '') {
+              root += '/' + path;
+              return <PatialPath {...props} src={path} key={idx} href={root} />;
+            } else null;
+          })}
+      </ol>
+    </StyledBreadcrumb>
+  );
+}
+
+Breadcrumb.defaultProps = {
+  width: 'fit-content',
+  splitter: '/',
+};

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -10,6 +10,7 @@ interface PatialPath {
   href: string;
   map?: { [key: string]: string };
   src: string;
+  current?: boolean;
 }
 interface BreadCrumb {
   src?: string;
@@ -44,20 +45,25 @@ export const StyledBreadcrumb = styled.nav<BreadcrumbSplitter>`
     text-decoration: none;
   }
 `;
-function PatialPath({ ...props }: PatialPath) {
-  if (props.map && props.map[props.src] === '') return null;
+function PatialPath({ map, src, href, current }: PatialPath) {
+  if (map && map[src] === '') return null;
+
   return (
     <li>
-      <a href={props.href}>
-        {props.map ? props.map[props.src] ?? props.map[props.href] : props.src}
-      </a>
+      {current ? (
+        <a href={href} aria-current="page">
+          {map ? map[src] ?? map[href] : src}
+        </a>
+      ) : (
+        <a href={href}>{map ? map[src] ?? map[href] : src}</a>
+      )}
     </li>
   );
 }
 export function Breadcrumb({ ...props }: BreadCrumb) {
   const src = props.src ? new URL(props.src) : window.location;
   let root = props.root ?? src.origin;
-
+  const BreadcrumbArray = src.href.replace(root, '').split('/');
   return (
     <StyledBreadcrumb
       splitter={props.splitter}
@@ -66,15 +72,20 @@ export function Breadcrumb({ ...props }: BreadCrumb) {
     >
       <ol>
         <PatialPath {...props} src={root} href={root} />
-        {src.href
-          .replace(root, '')
-          .split('/')
-          .map((path, idx) => {
-            if (path.trim() !== '') {
-              root += '/' + path;
-              return <PatialPath {...props} src={path} key={idx} href={root} />;
-            } else null;
-          })}
+        {BreadcrumbArray.map((path, idx) => {
+          if (path.trim() !== '') {
+            root += '/' + path;
+            return (
+              <PatialPath
+                {...props}
+                src={path}
+                key={idx}
+                href={root}
+                current={idx === BreadcrumbArray.length - 1}
+              />
+            );
+          } else null;
+        })}
       </ol>
     </StyledBreadcrumb>
   );

--- a/src/Breadcrumb/index.ts
+++ b/src/Breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumb';

--- a/src/Switch/Switch.tsx
+++ b/src/Switch/Switch.tsx
@@ -1,0 +1,101 @@
+import React,{ KeyboardEvent } from 'react';
+import styled from 'styled-components';
+interface Switch {
+  event?: () => void;
+  status?: boolean;
+  children?: string | JSX.Element;
+  text?: string;
+  offText?: string;
+  bar?: string | number;
+  bg?: string;
+  border?: string;
+  offBg?: string;
+  offBorder?: string;
+  delay?: string;
+  height?: string;
+  ratio?: string;
+  offBar?: string;
+}
+
+export const StyledSwitch = styled.div`
+  width: fit-content;
+  &:focus-visible {
+    outline: 2px solid #03a9f4;
+  }
+`;
+
+const Ball = styled.span<Switch>`
+  position: absolute;
+  top: 0px;
+  left: 2px;
+  display: inline-block;
+  border: 1px solid;
+  border-color: ${(props) => props.offBorder};
+  border-radius: 100%;
+  height: calc(${(props) => props.height} - 4px);
+  width: calc(${(props) => props.height} - 4px);
+  background: ${(props) => props.offBg};
+  transition: all ${(props) => (props.delay || '0.3') + 's'};
+
+  [aria-checked='true'] & {
+    transform: translate3d(-100%, 0, 0);
+    left: calc(
+      -2px + ${(props) => props.height} * ${(props) => Number(props.ratio)}
+    );
+    background: ${(props) => props.bg};
+    border-color: ${(props) => props.border};
+  }
+`;
+ const StyledTitle = styled.span`
+  margin-right: 10px;
+`;
+ const Bar = styled.span<Switch>`
+  position: relative;
+  display: inline-block;
+  vertical-align: bottom;
+  border: 2px solid;
+  border-color: ${(props) => props.offBorder};
+  border-radius: calc(${(props) => props.height});
+  background: ${(props) => props.offBar};
+  height: calc(${(props) => props.height});
+  width: calc(${(props) => props.height} * ${(props) => Number(props.ratio)});
+  [aria-checked='true'] & {
+    border-color: ${(props) => props.border};
+    background: ${(props) => props.bar};
+  }
+`;
+export const Text = styled.span`
+  margin-left: 10px;
+`;
+export function Switch(props: Switch) {
+  const handleKeyUp = ({ key }: KeyboardEvent<HTMLElement>) => {
+    if (props.event && (key === 'Tab' || key === ' ')) props.event();
+  };
+  return (
+    <StyledSwitch
+      onClick={props.event}
+      onKeyUp={handleKeyUp}
+      tabIndex={0}
+      role="switch"
+      aria-checked={props.status}
+    >
+      <StyledTitle>{props.children}</StyledTitle>
+      <Bar {...props}>
+        <Ball {...props}> </Ball>
+      </Bar>
+      <Text>{props.status ? props.text : props.offText}</Text>
+    </StyledSwitch>
+  );
+}
+Switch.defaultProps = {
+  offText: 'off',
+  text: 'on',
+  height: '20px',
+  bg: 'green',
+  border: 'green',
+  offBg: 'black',
+  ratio: '2',
+  bar: 'none',
+  offBar: 'none',
+  children: 'Switch',
+};

--- a/src/Switch/index.ts
+++ b/src/Switch/index.ts
@@ -1,0 +1,1 @@
+export * from './Switch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Alert } from './Alert';
 import { A11yHidden } from './A11yHidden';
+import {Breadcrumb} from "./Breadcrumb"
 import { Title } from './Title';
 import { Link } from './Link';
-export { Alert, A11yHidden, Title, Link };
+export { Alert, A11yHidden, Title, Link, Breadcrumb };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ import { A11yHidden } from './A11yHidden';
 import {Breadcrumb} from "./Breadcrumb"
 import { Title } from './Title';
 import { Link } from './Link';
-export { Alert, A11yHidden, Title, Link, Breadcrumb };
+import { Switch } from './Switch';
+export { Alert, A11yHidden, Title, Link, Breadcrumb, Switch };


### PR DESCRIPTION
## 개요
- 현재 주소를 기반으로 자동으로 Breadcrumb 구현

## 작업사항
- 자동으로 주소 값 입력
- Root가 되는 기본 주소를 설정할 수 있도록 구현(처음 path는 Root를 기준으로 생성)
- 특정 Key 값을 가진 path를 커스텀(주소의 path를 원하는 언어 혹은 원하는 단어로 변경 가능)
- width를 조정 기능 구현(Breadcrumb의 너비 변경 가능)
- splitter 커스터 기능 구현(path를 나누는 string 변경)

## 추후 개선사항
- 글자 색, 배경 색, padding 값 등 필요한 값을 커텀 할 수 있도록 구현 예정
- 
✅ close #26 
