### PR TITLE
Fix: Validate ways & focus control

### DIFF
--- a/src/List/ListItem.tsx
+++ b/src/List/ListItem.tsx
@@ -1,39 +1,47 @@
 import React, { useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
-import { getTabbableChildren, removeTabbable, restoreTabbable } from '../utils';
+import { getFocusableChildren, removeTabbable, restoreTabbable } from '../utils';
 
 export interface ListItemProps extends PropsWithHTMLAttr<HTMLLIElement> {
   children: React.ReactNode;
+  [key: string]: unknown;
 }
 
 export function ListItem({ children, ...restProps }: ListItemProps): JSX.Element {
   const containerRef = useRef<HTMLLIElement>(null);
 
-  let tabbableChildren: HTMLElement[] = [];
+  let $focusableChildren: HTMLElement[] = [];
 
   useEffect(() => {
     const $container = containerRef.current;
     if ($container) {
-      tabbableChildren = getTabbableChildren($container);
+      $focusableChildren = getFocusableChildren($container);
     }
   }, [children]);
 
   // li요소가 포커스를 받으면 자식들에 tab으로 접근 가능하도록 한다
   const handleFocus = (e: React.FocusEvent): void => {
     if (e.target === e.currentTarget) {
-      tabbableChildren.forEach(restoreTabbable);
+      $focusableChildren.forEach(restoreTabbable);
     }
   };
 
   // li가 포커스를 잃으면 자식들에도 tab으로 접근 불가능하도록 한다
   const handleBlur = (e: React.FocusEvent): void => {
     if (!e.currentTarget.contains(e.relatedTarget)) {
-      tabbableChildren.forEach(removeTabbable);
+      $focusableChildren.forEach(removeTabbable);
     }
   };
 
   return (
-    <Li ref={containerRef} onFocus={handleFocus} onBlur={handleBlur} tabIndex={0} {...restProps}>
+    <Li
+      ref={containerRef}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      tabIndex={0}
+      data-r-wai-component-name="ListItem"
+      {...restProps}
+    >
       {children}
     </Li>
   );

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -28,22 +28,57 @@ export const restrictChildren = <T extends ComponentType<any>>(
 ): void => {
   let isValid: boolean;
   let validComponentName: string;
+  let misusedComponent: ReactNode;
 
   if (Array.isArray(allowedComponent)) {
     isValid = Children.toArray(children).every((child) =>
-      allowedComponent.some((allowed) => isTargetComponent(child, allowed))
+      allowedComponent.some((allowed) => {
+        const isTargetValid = isTargetComponent(child, allowed);
+        if (!isTargetValid) {
+          misusedComponent = child;
+        }
+        return isTargetValid;
+      })
     );
     validComponentName = allowedComponent.map((Component) => Component.name).join(', ');
   } else {
-    isValid = Children.toArray(children).every((child) => isTargetComponent(child, allowedComponent));
+    isValid = Children.toArray(children).every((child) => {
+      const isTargetValid = isTargetComponent(child, allowedComponent);
+      if (!isTargetValid) {
+        misusedComponent = child;
+      }
+      return isTargetValid;
+    });
     validComponentName = allowedComponent.name;
   }
   if (!isValid) {
     const errorMessage = navigator.languages.includes('ko')
-      ? `웹 접근성을 준수하기 위하여, 허용된 컴포넌트만 children으로 사용할 수 있습니다.
-      사용 가능한 컴포넌트: ${validComponentName}`
+      ? `웹 접근성을 준수하기 위하여 허용된 컴포넌트만 children으로 사용할 수 있습니다.
+      사용 가능한 컴포넌트: ${validComponentName}
+      사용된 컴포넌트: ${misusedComponent}`
       : `Only following component is allowed for children to comply with web accessibility guidelines
-      allowed components: ${validComponentName}`;
+      allowed components: ${validComponentName}
+      misused component: ${misusedComponent}`;
     throw new Error(errorMessage);
   }
+};
+
+export const validateElements = (
+  children: HTMLElement[],
+  callback: (element: HTMLElement) => boolean,
+  errorMessage: string
+): void => {
+  const isValid = children.every(callback);
+  if (!isValid) {
+    throw new Error(errorMessage);
+  }
+};
+
+export const restrictElementsByComponetName = (children: HTMLElement[], allowedComponentName: string): void => {
+  const errorMessage = navigator.languages.includes('ko')
+    ? `웹 접근성을 준수하기 위하여 자식 요소로 ${allowedComponentName} 컴포넌트만을 가질 수 있습니다.`
+    : `Only following component is allowed for children to comply with web accessibility guidelines.
+    allowed components: ${allowedComponentName}`;
+
+  validateElements(children, (element) => element.dataset?.rWaiComponentName === allowedComponentName, errorMessage);
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -16,7 +16,7 @@ export const findChildComponent = <T extends ComponentType<any>>(Component: T, c
 export const enforceChildren = <T extends ComponentType<any>>(Component: T, children: ReactNode): void => {
   const isComponentExist = !!findChildComponent(Component, children);
   if (!isComponentExist) {
-    const errorMessage = navigator.languages.includes('ko')
+    const errorMessage = navigator?.languages.includes('ko')
       ? `웹 접근성을 준수하기 위하여 자식 요소로 ${Component.name} 컴포넌트를 필수적으로 가져야합니다.`
       : `Use ${Component.name} component for children to comply with web accessibility guidelines`;
     throw new Error(errorMessage);
@@ -52,7 +52,7 @@ export const restrictChildren = <T extends ComponentType<any>>(
     validComponentName = allowedComponent.name;
   }
   if (!isValid) {
-    const errorMessage = navigator.languages.includes('ko')
+    const errorMessage = navigator?.languages.includes('ko')
       ? `웹 접근성을 준수하기 위하여 허용된 컴포넌트만 children으로 사용할 수 있습니다.
       사용 가능한 컴포넌트: ${validComponentName}
       사용된 컴포넌트: ${misusedComponent}`
@@ -75,7 +75,7 @@ export const validateElements = (
 };
 
 export const restrictElementsByComponetName = (children: HTMLElement[], allowedComponentName: string): void => {
-  const errorMessage = navigator.languages.includes('ko')
+  const errorMessage = navigator?.languages.includes('ko')
     ? `웹 접근성을 준수하기 위하여 자식 요소로 ${allowedComponentName} 컴포넌트만을 가질 수 있습니다.`
     : `Only following component is allowed for children to comply with web accessibility guidelines.
     allowed components: ${allowedComponentName}`;


### PR DESCRIPTION
## 개요

- List 컴포넌트 사용 도중 발견한 버그를 해결하였습니다

## 작업사항

- 컴포넌트의 type 프로퍼티로 확인하던 방식에서 DOM요소의 data 프로퍼티를 확인하는 방법으로 유효성 검사 방법을 변경하였습니다
	- emotion의 css prop을 사용할 때 forwardRef로 컴포넌트가 래핑되어 제대로 확인할 수 없는 버그를 해결하였습니다
- 컴포넌트 리렌더링 시에도 포커스를 자연스럽게 유지하도록 코드를 수정하였습니다
	- 리렌더링 후 포커스를 이동할 때 탭시퀀스가 깨지는 버그를 해결하였습니다


✅ close #65 