### PR TITLE
[Feat] Improve keyboard navigation in Grid component

### DIFF
--- a/src/Grid/Grid.stories.tsx
+++ b/src/Grid/Grid.stories.tsx
@@ -26,12 +26,14 @@ export const Default = Template.bind({});
 Default.args = {
   container: true,
   spacing: 16,
-  style: { width: '400px', backgroundColor: 'pink' },
-  children: [1, 2, 3].map((key) => (
-    <Grid key={key} item xs={2} sm={6} style={{ height: '200px', backgroundColor: '#373829' }}>
-      <div style={{ width: '100%', height: '100%', backgroundColor: '#823843' }}>li {key}</div>
-    </Grid>
-  )),
+  style: { width: '1000px', backgroundColor: 'pink', margin: 0 },
+  children: Array(20)
+    .fill(null)
+    .map((_, key) => (
+      <Grid key={key} item xs={2} xl={6} style={{ height: '200px', backgroundColor: '#373829' }}>
+        <div style={{ width: '100%', height: '100%', backgroundColor: '#823843' }}>li {key}</div>
+      </Grid>
+    )),
 };
 
 export const NestedGrid = Template.bind({});

--- a/src/Grid/Grid.tsx
+++ b/src/Grid/Grid.tsx
@@ -81,12 +81,18 @@ export interface GridProps extends PropsWithHTMLAttr<HTMLDivElement> {
    * It can only be used on a type container component.
    */
   spacing?: number;
+  /**
+   * Determines number of rows to skip when pageup or pagedown key pressed.
+   * It can only be used on a type container component.
+   */
+  step?: number;
   className?: string;
   children?: React.ReactNode;
+  [key: string]: unknown;
 }
 
 export function Grid(props: GridProps): JSX.Element {
-  const { container, item, xs, sm, md, lg, xl, className, children, ...restProps } = props;
+  const { container, item, xs, sm, md, lg, xl, className, children, step = 5, ...restProps } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const breakpointStatusRef = useRef<Breakpoints<boolean>>({
@@ -112,7 +118,7 @@ export function Grid(props: GridProps): JSX.Element {
 
     if ((role === 'container' || role === 'both') && $container) {
       $gridTables = getGridTables($container);
-      navigators = getGridNavigators($gridTables);
+      navigators = getGridNavigators($gridTables, step);
     }
 
     if (role === 'item' && $container) {
@@ -176,7 +182,7 @@ export function Grid(props: GridProps): JSX.Element {
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>): void => {
     const key = getCompatibleKey(e);
-    if (!NAVIGATION_KEYS.includes(key) || role === 'item' || e.target === e.currentTarget) return;
+    if (!NAVIGATION_KEYS.find((k) => k === key) || role === 'item' || e.target === e.currentTarget) return;
 
     const navigator = navigators[breakpointRef.current];
     if (!navigator) return;
@@ -186,6 +192,10 @@ export function Grid(props: GridProps): JSX.Element {
     else if (key === KEYS.ARROW_DOWN) navigator.down();
     else if (key === KEYS.ARROW_LEFT) navigator.left();
     else if (key === KEYS.ARROW_RIGHT) navigator.right();
+    else if (key === KEYS.HOME) e.ctrlKey ? navigator.ctrlHome() : navigator.home();
+    else if (key === KEYS.END) e.ctrlKey ? navigator.ctrlEnd() : navigator.end();
+    else if (key === KEYS.PAGE_UP) !e.ctrlKey && navigator.pageup();
+    else if (key === KEYS.PAGE_DOWN) !e.ctrlKey && navigator.pagedown();
 
     e.stopPropagation();
   };
@@ -195,7 +205,6 @@ export function Grid(props: GridProps): JSX.Element {
   return (
     <Div
       ref={containerRef}
-      role={container ? 'grid' : 'gridcell'}
       css={[containerCss, itemCss]}
       className={`${item ? GRID_ITEM_CLASSNAME : ''} ${className ?? ''}`}
       tabIndex={item ? 0 : undefined}

--- a/src/Grid/Grid.tsx
+++ b/src/Grid/Grid.tsx
@@ -133,7 +133,6 @@ export function Grid(props: GridProps): JSX.Element {
       const updateBreakpoint = (mediaQueryList: MediaQueryList, breakpoint: Breakpoint): void => {
         breakpointStatusRef.current[breakpoint] = mediaQueryList.matches;
         breakpointRef.current = getPriorBreakpoint(breakpointStatusRef.current);
-        console.log($gridTables, breakpointRef.current);
       };
 
       const breakpoints = breakpointKeys;

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -100,7 +100,7 @@ export function List({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLUListElement | HTMLOListElement>): void => {
     const key = getCompatibleKey(e);
-    if (!NAVIGATION_KEYS.includes(key)) return;
+    if (!NAVIGATION_KEYS.find((k) => k === key)) return;
 
     e.preventDefault();
     // List 컴포넌트에서는 ListItem(li 태그) 사이 키보드 네비게이션만을 제어한다.

--- a/src/utils/keyboardNavigation.ts
+++ b/src/utils/keyboardNavigation.ts
@@ -42,7 +42,7 @@ export const NAVIGATION_KEYS = [
 ];
 
 export const getCompatibleKey = (keyEvent: React.KeyboardEvent<HTMLElement>): string => {
-  const { altKey, metaKey, key } = keyEvent;
+  const { metaKey, key } = keyEvent;
 
   const isWindows = navigator?.userAgent.toLowerCase().includes('windows');
   if (isWindows) {
@@ -50,12 +50,8 @@ export const getCompatibleKey = (keyEvent: React.KeyboardEvent<HTMLElement>): st
   }
 
   if (metaKey) {
-    if (key === KEYS.ARROW_UP || key === KEYS.ARROW_LEFT) return KEYS.HOME;
-    if (key === KEYS.ARROW_DOWN || key === KEYS.ARROW_RIGHT) return KEYS.END;
-  }
-  if (altKey) {
-    if (key === KEYS.ARROW_UP || key === KEYS.ARROW_LEFT) return KEYS.PAGE_UP;
-    if (key === KEYS.ARROW_DOWN || key === KEYS.ARROW_RIGHT) return KEYS.PAGE_DOWN;
+    if (key === KEYS.ARROW_UP) return KEYS.HOME;
+    if (key === KEYS.ARROW_DOWN) return KEYS.END;
   }
   return key;
 };

--- a/src/utils/keyboardNavigation.ts
+++ b/src/utils/keyboardNavigation.ts
@@ -17,7 +17,18 @@ export const KEYS = {
   PAGE_UP: 'PageUp',
   PAGE_DOWN: 'PageDown',
   ESCAPE: 'Escape',
-};
+} as const;
+
+export type KeyOfKEYS = keyof typeof KEYS;
+export type ValueOfKEYS = (typeof KEYS)[KeyOfKEYS];
+
+export const COMBINATION_KEYS = {
+  CTRL_HOME: 'Control+Home',
+  CTRL_END: 'Control+End',
+} as const;
+
+export type KeyOfCombinationKeys = keyof typeof COMBINATION_KEYS;
+export type ValueOfCombinationKeys = (typeof COMBINATION_KEYS)[KeyOfCombinationKeys];
 
 export const NAVIGATION_KEYS = [
   KEYS.ARROW_UP,


### PR DESCRIPTION
## 개요

- Grid 컴포넌트 키보드 내비게이션 개선

## 작업사항

특수키를 활용한 이동이 가능하도록 내비게이션을 확장하였습니다

### 추가된 네비게이션 키
- Home: 현재 행의 가장 첫번째 그리드 아이템으로 이동
- End: 현재 행의 가장 마지막 그리드 아이템으로 이동
- PageUp: 사용자가 지정한 만큼 이전 행으로 이동. 기본값은 5
- PageDown: 사용자가 지정한 만큼 다음 행으로 이동. 기본값은 5
- Ctrl+Home: 같은 계층 내 그리드 아이템 중 첫번째 그리드 아이템으로 이동
- Ctrl+End: 같은 계층 내 그리드 아이템 중 마지막 그리드 아이템으로 이동


✅ close #67 
